### PR TITLE
Validate binlog positions against those in DB

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -16,8 +16,8 @@
                                   :profiles [:lib :dev]
                                   :schemas [LibConf]}))
 
-(reloaded.repl/set-init! #(system/only-stream (config) {:file nil :position 0}))
-;; (reloaded.repl/set-init! #(system/with-initial-load (config)))
+;; (reloaded.repl/set-init! #(system/only-stream (config) {:file "some-valid-filename.000010" :position 0}))
+(reloaded.repl/set-init! #(system/with-initial-load (config)))
 
 (defn reset []
   (reloaded.repl/reset))
@@ -38,6 +38,8 @@
   (reset)
   (init)
 
+  (config)
+
   (-> system :loader :out-rows deref count)
   (-> system :loader :out-rows deref first)
   (-> system :loader :out-rows deref last)
@@ -49,6 +51,8 @@
   (-> system :streamer :binlog-pos)
 
   (reloaded.repl/stop)
+
+  (dumpr/valid-binlog-pos? (:conf system) {:file "Tamma-bin.000013" :position 0})
   )
 
 

--- a/src/dumpr/binlog.clj
+++ b/src/dumpr/binlog.clj
@@ -14,9 +14,9 @@
     (onConnect [this client]
       (log/info "BinaryLogClient connected"))
     (onCommunicationFailure [this client ex]
-      (log/info (str "BinaryLogClient communication failure: " (.getMessage ex))))
+      (log/warn "BinaryLogClient communication failure: " ex))
     (onEventDeserializationFailure [this client ex]
-      (log/info (str "BinaryLogClient event deserialization failure: " (.getMessage ex))))
+      (log/warn "BinaryLogClient event deserialization failure: " ex))
     (onDisconnect [this client]
       (log/info "BinaryLogClient disconnected"))))
 

--- a/src/dumpr/plan.org
+++ b/src/dumpr/plan.org
@@ -7,11 +7,11 @@
  - [X] cache table schemas
  - [X] Convert text type columns to strings using proper encoding
  - [X] Automated tests for loading and streaming
- - [ ] What happens if the given binary log position is invalid
- - [ ] What happens if DB connection drops, can we reconnect?
+ - [X] What happens if DB connection drops, can we reconnect?
+ - [ ] Automated tests for connection failures and resuming?
+ - [X] Validate given binlog stream start positition against available positions
  - [ ] Create an example application that uses Dumpr library
  - [ ] stop event handling
- - [X] testing strategy
  - [ ] channel metrics
  - [ ] Test nexted tx?
  - [ ] write good README

--- a/src/dumpr/query.clj
+++ b/src/dumpr/query.clj
@@ -20,6 +20,11 @@
   [db-spec]
   (first (jdbc/query db-spec ["SHOW MASTER STATUS"])))
 
+(defn show-binlog-positions
+  "List all available binary log positions."
+  [db-spec]
+  (jdbc/query db-spec ["SHOW BINARY LOGS"]))
+
 (defn stream-table
   "Stream the contents of a given database table to a core.async
   channel. Designed to work as async-fn of


### PR DESCRIPTION
- Expose an API operation to validate binlog position
- Throw exception if binlog-stream is being attempted to create with an invalid binlog position
