### PR TITLE
Clarify dumpr public interface

### DIFF
--- a/dev/system.clj
+++ b/dev/system.clj
@@ -66,9 +66,9 @@
     (if-not (some? (:stream this))
       (let [binlog-pos (or (:binlog-pos this)
                            (-> loader :result :binlog-pos))
-            stream (dumpr/binlog-stream conf binlog-pos (:filter-tables this))
+            stream (dumpr/create-stream conf binlog-pos (:filter-tables this))
             out-events (sink (:out stream) println)]
-        (dumpr/start-binlog-stream stream)
+        (dumpr/start-stream stream)
         (-> this
             (assoc :binlog-pos binlog-pos)
             (assoc :out-events out-events)
@@ -76,7 +76,7 @@
 
   (stop [this]
     (when (some? (:stream this))
-      (dumpr/close-binlog-stream (:stream this)))
+      (dumpr/stop-stream (:stream this)))
     (dissoc this :stream)))
 
 (defn create-stream-continue [conf binlog-pos filter-tables]

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -50,6 +50,8 @@
   (-> system :streamer :out-events deref)
   (-> system :streamer :binlog-pos)
 
+  (-> system :conf)
+
   (reloaded.repl/stop)
 
   (dumpr/valid-binlog-pos? (:conf system) {:file "Tamma-bin.000013" :position 0})

--- a/src/dumpr/binlog.clj
+++ b/src/dumpr/binlog.clj
@@ -50,9 +50,8 @@
     (.registerEventListener (event-listener out))
     (.registerLifecycleListener (lifecycle-listener))))
 
-;; TODO configurable connection timeout?
-(defn start-client [^BinaryLogClient client]
-  (.connect client 3000))
+(defn start-client [^BinaryLogClient client timeout]
+  (.connect client timeout))
 
 (defn stop-client [^BinaryLogClient client]
   (.disconnect client))

--- a/test/dumpr/core_test.clj
+++ b/test/dumpr/core_test.clj
@@ -138,14 +138,14 @@
   (let [{:keys [conn-params]} (test-util/config)
         conf (dumpr/create-conf conn-params {})
         stream (if (seq tables)
-                 (dumpr/binlog-stream conf binlog-pos #{:widgets :manufacturers})
-                 (dumpr/binlog-stream conf binlog-pos))]
-    (dumpr/start-binlog-stream stream)
+                 (dumpr/create-stream conf binlog-pos #{:widgets :manufacturers})
+                 (dumpr/create-stream conf binlog-pos))]
+    (dumpr/start-stream stream)
     stream))
 
 (defn- stream-to-coll-and-close [stream n]
   (let [out (<!! (test-util/sink-to-coll (:out stream) n))]
-    (dumpr/close-binlog-stream stream)
+    (dumpr/stop-stream stream)
     out))
 
 


### PR DESCRIPTION
- make connection timeout configurable
- explicitly define default values for optional connection timeout
  configuration options instead of relying on underlying mysql binlog
  connector java lib defaults.
- rename API methods to be consistent
- Add documentation
