### PR TITLE
Switch Timbre to clojure.tools.logging

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -3,7 +3,7 @@
             [system :as system :refer [LibConf]]
             [dumpr.core :as dumpr]
             [clojure.core.async :as async :refer [<! go-loop >! timeout]]
-            [taoensso.timbre :as log]
+            [clojure.tools.logging :as log]
             [io.aviso.config :as config]
             [manifold.stream :as s]
             [manifold.deferred :as d]))

--- a/project.clj
+++ b/project.clj
@@ -7,10 +7,10 @@
 
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/core.async "0.2.374"]
+                 [org.clojure/tools.logging "0.3.1"]
                  [mysql/mysql-connector-java "5.1.38"]
                  [org.clojure/java.jdbc "0.4.2"]
                  [prismatic/schema "1.0.4"]
-                 [com.taoensso/timbre "4.1.2"]
                  [com.github.shyiko/mysql-binlog-connector-java "0.2.3"]
                  [manifold "0.1.1"]]
 

--- a/src/dumpr/binlog.clj
+++ b/src/dumpr/binlog.clj
@@ -1,6 +1,6 @@
 (ns dumpr.binlog
   (:require [clojure.core.async :as async :refer [chan >!!]]
-            [taoensso.timbre :as log]
+            [clojure.tools.logging :as log]
             [dumpr.query :as query])
   (:import [com.github.shyiko.mysql.binlog
             BinaryLogClient

--- a/src/dumpr/core.clj
+++ b/src/dumpr/core.clj
@@ -4,7 +4,7 @@
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.core.async :as async :refer [chan >!!]]
             [schema.core :as s]
-            [taoensso.timbre :as log]
+            [clojure.tools.logging :as log]
             [manifold.stream]
             [dumpr.query :as query]
             [dumpr.table-schema :as table-schema]

--- a/src/dumpr/query.clj
+++ b/src/dumpr/query.clj
@@ -2,7 +2,7 @@
   "Functions to query data from MySQL and parse the query results."
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.core.async :as async :refer [>!!]]
-            [taoensso.timbre :as log]
+            [clojure.tools.logging :as log]
             [dumpr.row-format :as row-format]))
 
 

--- a/src/dumpr/stream.clj
+++ b/src/dumpr/stream.clj
@@ -3,7 +3,7 @@
   (:require [clojure.core.async :as async :refer [go go-loop <! >! thread chan]]
             [schema.core :as s]
             [dumpr.table-schema :as table-schema]
-            [taoensso.timbre :as log]
+            [clojure.tools.logging :as log]
             [manifold.stream]
             [dumpr.query :as query]
             [dumpr.utils :as utils]


### PR DESCRIPTION
clojure.tools.logging is better for a library project because it bridges
logging to which ever logging library the application developer has
chosen (including Timbre). Timbre is great library but imposing it on
library users is not a decision for library author to make.
